### PR TITLE
meta rules & engine abstraction

### DIFF
--- a/app/Repl.hs
+++ b/app/Repl.hs
@@ -1,5 +1,7 @@
 module Repl ( startRepl ) where
 
+import Debug.Trace
+
 import Parsers
 import System.IO
 import Control.Applicative
@@ -9,7 +11,8 @@ import qualified Expr
 import qualified Data.Map.Strict as Map
 
 data ReplAction
-  = Def (String, Expr.Rule) -- Define a new rule (name, rule)
+  = Meta Expr.Rule Expr.Rule
+  | Def (String, Expr.Rule) -- Define a new rule (name, rule)
   | Shape Expr.Expr         -- Begin shaping an expression
   | Apply String
   | Done
@@ -51,9 +54,34 @@ readInputAction ctx input =
 processAction :: ReplContext -> ReplAction -> ActionResult
 processAction ctx parseResult =
   case parseResult of
-    Done             -> Right ctx { cExpr=Nothing }
-    Shape expr       -> Right ctx { cExpr=Just expr }
-    Def (name, rule) -> Right ctx { cRules=Map.insert name rule (cRules ctx) }
+    Done                   -> Right ctx { cExpr=Nothing }
+    Shape expr             -> Right ctx { cExpr=Just expr }
+    Def (name, rule)       -> Right ctx { cRules=Map.insert name rule (cRules ctx) }
+
+    Meta rHead rBody ->
+      let testRule = Expr.Rule {
+        Expr.hd =
+          Expr.Fun (Expr.Sym "swap") [Expr.Fun (Expr.Sym "pair") [Expr.Var "A", Expr.Var "B"]],
+        Expr.body =
+          Expr.Fun (Expr.Sym "pair") [Expr.Var "B", Expr.Var "A"]} in
+      trace ("swap rule: " <> show testRule) $
+
+      let headBindings = Expr.match (Expr.hd rHead) (Expr.hd testRule) in
+      let bodyBindings = Expr.match (Expr.body rHead) (Expr.body testRule) in
+      let bindings     = Expr.mergeBindings headBindings bodyBindings in
+      let new_head     = Expr.substBindings bindings (Expr.hd rBody) in
+      let new_body     = Expr.substBindings bindings (Expr.body rBody) in
+      let new_rule     = Expr.Rule {Expr.hd=new_head, Expr.body=new_body} in 
+      
+      trace ("new rule: " <> show new_rule) 
+
+      --let headApply = Expr.applyAll rHead (Expr.hd testRule) in
+      --let bodyApply = Expr.applyAll rBody (Expr.body testRule) in
+      --let metaRule = Expr.Rule {Expr.hd = headApply, Expr.body = bodyApply} in
+      --trace ("(" <> show headApply <> ") = (" <> show bodyApply <> ")") 
+      --trace ("meta rule -> " <> show metaRule) 
+        Right ctx
+
     Apply name       ->
       case cExpr ctx of
         Nothing   -> Left "Attempted to apply rule outside of shaping"
@@ -65,13 +93,25 @@ processAction ctx parseResult =
 {--REPL COMMAND PARSERS--------------------------------------------------------}
 
 parseReplAction :: StrParser ReplAction
-parseReplAction = ruleParser <|> shapeParser <|> applyParser <|> doneParser
+parseReplAction = ruleParser  <|> 
+                  metaParser  <|>
+                  shapeParser <|> 
+                  applyParser <|> 
+                  doneParser
 
 identParser :: StrParser String
 identParser = do
   first <- alphaP
   rest  <- many (charP '_' <|> alphaP <|> digitP)
   pure (first:rest)
+
+metaParser :: StrParser ReplAction
+metaParser = do
+  _      <- stringP "meta"                           <* ws
+  ruleHd <- charP '(' *> Expr.parseRule <* charP ')' <* ws
+  _      <- ws *> charP '='                          <* ws
+  ruleTl <- charP '(' *> Expr.parseRule <* charP ')' <* ws
+  pure $ Meta ruleHd ruleTl
 
 ruleParser :: StrParser ReplAction
 ruleParser = do

--- a/app/Repl.hs
+++ b/app/Repl.hs
@@ -2,34 +2,12 @@ module Repl ( startRepl ) where
 
 import Parsers
 import System.IO
-import Control.Applicative
-import Data.Map.Strict (Map)
-
-import qualified Expr
-import qualified Data.Map.Strict as Map
-
-data ReplAction
-  = Meta String Expr.Rule Expr.Rule -- Define a meta rule [name (A = B) = (C = D)]
-  | Def String Expr.Rule String     -- Define a new rule (name, rule, metas)
-  | Shape Expr.Expr                 -- Begin shaping an expression
-  | Apply String
-  | Done
-  deriving Show
-
-data ReplContext = Context {
-  cMetas :: Map String (Expr.Rule, Expr.Rule), -- meta rules defined in the ctx
-  cRules :: Map String Expr.Rule,              -- rules defined in the context
-  cExpr  :: Maybe Expr.Expr                    -- current expression being shaped
-} deriving Show
-
-type ActionResult = Either String ReplContext
+import qualified Engine
 
 startRepl :: IO ()
-startRepl = repl Context { cMetas = Map.empty,
-                           cRules = Map.empty,
-                           cExpr  = Nothing }
+startRepl = repl Engine.empty
 
-repl :: ReplContext -> IO ()
+repl :: Engine.Context -> IO ()
 repl ctx = do
   hFlush stdout
   putStr "emm> "; hFlush stdout
@@ -38,7 +16,7 @@ repl ctx = do
   case readInputAction ctx userInput of
     Left errMsg -> do putStrLn errMsg; hFlush stdout; repl ctx
     Right ctx'  ->
-      case cExpr ctx' of
+      case Engine.ctxExpr ctx' of
         Nothing   -> repl ctx' -- Not currently shaping an expression
         Just expr -> do        -- Currently shaping expression [expr]
           putStrLn $ "=> " <> show expr; hFlush stdout
@@ -46,107 +24,10 @@ repl ctx = do
 
   pure ()
 
-readInputAction :: ReplContext -> String -> ActionResult
+readInputAction :: Engine.Context -> String -> Engine.CtxResult
 readInputAction ctx input =
-  case parse parseReplAction input of
-    Left err     -> Left (fmtError err)
-    Right action -> processAction ctx action
-
-{- EXAMPLE META RULE APPLICATION TO CREATE A NEW RULE
-let testRule = Expr.Rule {
-  Expr.hd =
-    Expr.Fun (Expr.Sym "swap") [Expr.Fun (Expr.Sym "pair") [Expr.Var "A", Expr.Var "B"]],
-  Expr.body =
-    Expr.Fun (Expr.Sym "pair") [Expr.Var "B", Expr.Var "A"]} in
-trace ("swap rule: " <> show testRule) $
-
-
-let headBindings = Expr.match (Expr.hd rHead) (Expr.hd testRule) in
-let bodyBindings = Expr.match (Expr.body rHead) (Expr.body testRule) in
-let bindings     = Expr.mergeBindings headBindings bodyBindings in
-let new_head     = Expr.substBindings bindings (Expr.hd rBody) in
-let new_body     = Expr.substBindings bindings (Expr.body rBody) in
-let new_rule     = Expr.Rule {Expr.hd=new_head, Expr.body=new_body} in
-
-trace ("new rule: " <> show new_rule) Right ctx
--}
-
+  case parse Engine.parseCtxAction input of
+    Left err     -> Left (fmtError err)             -- parse error
+    Right action -> Engine.processAction action ctx -- user error or new context
+   
 -- TODO: Parser error while shaping expression causes shaping mode to end
--- TODO: Allow rule to inherit multiple meta rules
--- TODO: Allow meta rules to be completely optional on a rule definition
--- TODO: ??? Maybe move meta rule logic to core engine sense it requires
---       matching, merging and substitution
-processAction :: ReplContext -> ReplAction -> ActionResult
-processAction ctx parseResult =
-  case parseResult of
-    Done                  -> Right ctx { cExpr=Nothing }
-    Shape expr            -> Right ctx { cExpr=Just expr }
-    Def name rule meta    ->
-      case Map.lookup meta (cMetas ctx) of
-        Nothing             -> Left $ "Using unknown meta rule: " <> meta
-        Just (rHead, rBody) ->
-          let headBindings  = Expr.match (Expr.hd rHead) (Expr.hd rule) in
-          let bodyBindings  = Expr.match (Expr.body rHead) (Expr.body rule) in
-          let bindings      = Expr.mergeBindings headBindings bodyBindings in
-          let new_head      = Expr.substBindings bindings (Expr.hd rBody) in
-          let new_body      = Expr.substBindings bindings (Expr.body rBody) in
-          let new_rule      = Expr.Rule {Expr.hd=new_head, Expr.body=new_body} in
-          let new_rule_name = name <> "_" <> meta in
-          Right ctx { cRules = Map.insert name rule $
-                               Map.insert new_rule_name new_rule (cRules ctx) }
-
-    Meta name rHead rBody -> Right ctx { cMetas=Map.insert name (rHead, rBody) (cMetas ctx) }
-    Apply name            ->
-      case cExpr ctx of
-        Nothing   -> Left "Attempted to apply rule outside of shaping"
-        Just expr ->
-          case Map.lookup name (cRules ctx) of
-            Nothing   -> Left ("Attempted to apply unbound rule: " <> name)
-            Just rule -> Right ctx { cExpr=Just (Expr.applyAll rule expr) }
-
-{--REPL COMMAND PARSERS--------------------------------------------------------}
-
-parseReplAction :: StrParser ReplAction
-parseReplAction = ruleParser  <|> 
-                  metaParser  <|>
-                  shapeParser <|> 
-                  applyParser <|> 
-                  doneParser
-
-identParser :: StrParser String
-identParser = do
-  first <- alphaP
-  rest  <- many (charP '_' <|> alphaP <|> digitP)
-  pure (first:rest)
-
-metaParser :: StrParser ReplAction
-metaParser = do
-  _      <- stringP "meta"                           <* ws
-  name   <- identParser                              <* ws
-  ruleHd <- charP '(' *> Expr.parseRule <* charP ')' <* ws
-  _      <- ws *> charP '='                          <* ws
-  ruleTl <- charP '(' *> Expr.parseRule <* charP ')' <* ws
-  pure $ Meta name ruleHd ruleTl
-
-ruleParser :: StrParser ReplAction
-ruleParser = do
-  _    <- stringP "rule" <* ws
-  name <- identParser    <* ws
-  rule <- Expr.parseRule <* ws
-  meta <- charP '[' *> ws *> identParser <* ws <* charP ']'
-  pure $ Def name rule meta
-
-shapeParser :: StrParser ReplAction
-shapeParser = do
-  _ <- stringP "shape" <* ws
-  Shape <$> Expr.parseExpr
-
-applyParser :: StrParser ReplAction
-applyParser = do
-  _ <- stringP "apply" <* ws
-  Apply <$> identParser
-
-doneParser :: StrParser ReplAction
-doneParser = do
-  _ <- stringP "done" <* ws
-  pure Done

--- a/emm.cabal
+++ b/emm.cabal
@@ -7,19 +7,24 @@ author:             Teague Hansen
 maintainer:         thanse23@asu.edu
 build-type:         Simple
 
-common warnings
-    ghc-options: -Wall
+common common-settings
+  default-language: Haskell2010
+  ghc-options: -Wall
 
 library
-  import:          warnings
+  import:          common-settings
   hs-source-dirs:  src
-  exposed-modules: Expr,
-                   Parsers
+  exposed-modules:
+    Engine
+    Parsers
+  other-modules:
+    Engine.Expr
+    Engine.Context
   build-depends:   base ^>=4.17.2.1,
                    containers
 
 executable emm
-  import:           warnings
+  import:           common-settings
   main-is:          Main.hs
   hs-source-dirs:   app
   default-language: Haskell2010
@@ -29,7 +34,7 @@ executable emm
                     emm
 
 test-suite emm-test
-  import:         warnings
+  import:         common-settings
   type:           exitcode-stdio-1.0
   hs-source-dirs: test
   main-is:        Spec.hs

--- a/src/Engine.hs
+++ b/src/Engine.hs
@@ -1,0 +1,19 @@
+module Engine
+  ( Expr(..)
+  , Rule(..)
+  , Context
+  , CtxAction
+  , CtxResult
+  , empty
+  , ctxExpr
+  , processAction
+  , parseCtxAction
+  , parseExpr
+  , parseRule
+  , applyAll
+  ) 
+  where
+
+import Engine.Expr
+import Engine.Context
+

--- a/src/Engine/Context.hs
+++ b/src/Engine/Context.hs
@@ -1,0 +1,123 @@
+-- An extension ontop of the core pattern matching engine found in [Expr.hs]
+-- providing a context holding sets of rules and actions on expressions using
+-- those rules
+module Engine.Context 
+  ( Context
+  , CtxAction
+  , CtxResult
+  , Engine.Context.empty
+  , ctxExpr
+  , processAction
+  , parseCtxAction
+  )
+  where
+
+import Parsers
+import Engine.Expr
+import Control.Applicative
+import Data.Map.Strict (Map)
+import Data.Maybe (mapMaybe)
+
+import qualified Data.Map.Strict as Map
+
+data CtxAction
+  = Meta  String MetaRule
+  | Def   String Rule (Maybe [String])
+  | Shape Expr
+  | Apply String
+  | Done
+
+data Context = Context 
+  { cMetas :: Map String MetaRule,
+    cRules :: Map String Rule,
+    cExpr  :: Maybe Expr }
+
+type MetaRule = (Rule, Rule)
+type CtxResult = Either String Context
+
+empty :: Context
+empty = Context {cMetas = Map.empty, cRules = Map.empty, cExpr = Nothing}
+
+ctxExpr :: Context -> Maybe Expr
+ctxExpr = cExpr
+
+processAction :: CtxAction -> Context -> CtxResult
+processAction action ctx =
+  case action of
+    Done                 -> Right ctx {cExpr = Nothing}
+    Shape expr           -> Right ctx {cExpr = Just expr}
+    Meta name (lhs, rhs) -> Right ctx {cMetas = Map.insert name (lhs, rhs) (cMetas ctx)}
+    Apply name           ->
+      case cExpr ctx of
+        Nothing   -> Left "Rule application is not allowed outside of shaping"
+        Just expr ->
+          case Map.lookup name (cRules ctx) of
+            Nothing   -> Left $ name <> " is not a currently bound rule"
+            Just rule -> Right ctx {cExpr = Just $ applyAll rule expr}
+    Def name rule mMetas ->
+      case mMetas of
+        Nothing    -> Right ctx {cRules = Map.insert name rule (cRules ctx)}
+        Just metas ->
+          let metaCtx = cMetas ctx in -- note we disregaurd unknown meta rule names
+          let ruleCtx = cRules ctx in -- here by using [mapMaybe] below
+          let newRuleCtx = foldr 
+                (\(n, r) mmap -> Map.insert (name <> "_" <> n) (createMetaRule r rule) mmap) ruleCtx 
+                (mapMaybe (\n -> (,) n <$> Map.lookup n metaCtx) metas) in
+              Right ctx {cRules=Map.insert name rule newRuleCtx}
+
+    
+createMetaRule :: MetaRule -> Rule -> Rule 
+createMetaRule (lhs, rhs) rule =
+  let headBindings = match (hd lhs) (hd rule)
+      bodyBindings = match (body lhs) (body rule)
+      bindings     = mergeBindings headBindings bodyBindings
+      newLhs       = substBindings bindings (hd rhs)
+      newRhs       = substBindings bindings (body rhs) in
+      Rule {hd = newLhs, body = newRhs}
+ 
+{--CONTEXT ACTION PARSERS------------------------------------------------------}
+
+parseCtxAction :: StrParser CtxAction
+parseCtxAction =  ruleParser
+              <|> metaParser
+              <|> shapeParser
+              <|> applyParser
+              <|> doneParser
+
+identParser :: StrParser String
+identParser = do
+  first <- alphaP
+  rest  <- many (charP '_' <|> alphaP <|> digitP)
+  pure (first:rest)
+
+metaParser :: StrParser CtxAction
+metaParser = do
+  _    <- stringP "meta"                      <* ws
+  name <- identParser                         <* ws
+  lhs  <- charP '(' *> parseRule <* charP ')' <* ws
+  _    <- ws *> charP '='                     <* ws
+  rhs  <- charP '(' *> parseRule <* charP ')' <* ws
+  pure $ Meta name (lhs, rhs)
+
+ruleParser :: StrParser CtxAction
+ruleParser = do
+  _    <- stringP "rule" <* ws
+  name <- identParser    <* ws
+  rule <- parseRule      <* ws
+  meta <- optional $ charP '[' *> ws *> sepBy (ws *> charP ',' <* ws) identParser
+  pure $ Def name rule meta
+
+shapeParser :: StrParser CtxAction
+shapeParser = do
+  _ <- stringP "shape" <* ws
+  Shape <$> parseExpr
+
+applyParser :: StrParser CtxAction
+applyParser = do
+  _ <- stringP "apply" <* ws
+  Apply <$> identParser
+
+doneParser :: StrParser CtxAction
+doneParser = do
+  _ <- stringP "done" <* ws
+  pure Done

--- a/src/Engine/Expr.hs
+++ b/src/Engine/Expr.hs
@@ -1,14 +1,4 @@
-module Expr 
-  ( Expr(..)
-  , Rule(..)
-  , match
-  , applyAll
-  , substBindings
-  , mergeBindings
-  , parseRule
-  , parseExpr
-  )
-  where
+module Engine.Expr where
 
 import Parsers
 import Prelude hiding (lookup, head)
@@ -56,13 +46,13 @@ mergeBindings = merge preserveMissing
 substBindings :: Bindings -> Expr -> Expr
 substBindings bindings expr =
   case expr of
-    Sym _ -> expr
-    Var name -> fromMaybe expr (Map.lookup name bindings)
+    Sym _         -> expr
+    Var name      -> fromMaybe expr (Map.lookup name bindings)
     Fun head args ->
       let new_head = substBindings bindings head
           new_args = map (substBindings bindings) args in
-      Fun new_head new_args
-
+          Fun new_head new_args
+           
 -- Pattern match across two expressions creating a set of bindings between the
 -- two
 match :: Expr -> Expr -> Bindings

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -1,7 +1,10 @@
 module Expr 
   ( Expr(..)
   , Rule(..)
+  , match
   , applyAll
+  , substBindings
+  , mergeBindings
   , parseRule
   , parseExpr
   )


### PR DESCRIPTION
### Engine Abstraction
Logic that was in the repl that was maintaining a context and parsing actions has been moved into its own layer of logic to decouple it from repl logic. In the future this will let us easily parse files.
### Meta Rules
Meta rules allow for generic pattern matching on rules. Consider the following example:
```emm
meta rev (A = B) = (B = A)
rule swap swap(pair(A, B)) = pair(B, A) [rev]
```
In the program above we defined a meta rule `rev` which simply reverses a rule. The swap rule inherits an instance of this meta rule by adding`[rev]` at the end of its definition. When the expression engine parses the swap rule it creates another rule `swap_rev` which will look like this:
```emm
rule swap_rev pair(B, A) = swap(pair(A, B))
```
To understand what happened here we can see that the meta rule matched `A = swap(pair(A, B))` and `B = pair(B, A)` which bound these match variables in the rule expression `(B = A)` resulting in the rule above.