### PR TITLE
Binary Operators

### DIFF
--- a/app/Repl.hs
+++ b/app/Repl.hs
@@ -13,14 +13,18 @@ repl ctx = do
   putStr "emm> "; hFlush stdout
   userInput <- getLine
 
-  case readInputAction ctx userInput of
-    Left errMsg -> do putStrLn errMsg; hFlush stdout; repl ctx
-    Right ctx'  ->
-      case Engine.ctxExpr ctx' of
-        Nothing   -> repl ctx' -- Not currently shaping an expression
-        Just expr -> do        -- Currently shaping expression [expr]
-          putStrLn $ "=> " <> show expr; hFlush stdout
-          repl ctx'
+  if userInput == ""
+     then repl ctx
+     else
+
+    case readInputAction ctx userInput of
+      Left errMsg -> do putStrLn errMsg; hFlush stdout; repl ctx
+      Right ctx'  ->
+        case Engine.ctxExpr ctx' of
+          Nothing   -> repl ctx' -- Not currently shaping an expression
+          Just expr -> do        -- Currently shaping expression [expr]
+            putStrLn $ "=> " <> show expr; hFlush stdout
+            repl ctx'
 
   pure ()
 

--- a/src/Engine/Context.hs
+++ b/src/Engine/Context.hs
@@ -86,7 +86,7 @@ parseCtxAction =  ruleParser
 
 identParser :: StrParser String
 identParser = do
-  first <- alphaP
+  first <- alphaP <|> digitP
   rest  <- many (charP '_' <|> alphaP <|> digitP)
   pure (first:rest)
 

--- a/src/Engine/Expr.hs
+++ b/src/Engine/Expr.hs
@@ -18,10 +18,10 @@ data Expr
   | Var String
   | Fun Expr [Expr]
   | Op OpKind Expr Expr
-  deriving (Eq, Show)
+  deriving Eq
 
 data OpKind = Add | Sub | Mul | Div | Pow
-  deriving (Eq, Show)
+  deriving Eq
 
 data Rule = Rule
   { hd :: Expr
@@ -30,7 +30,6 @@ data Rule = Rule
 
 type Bindings = Map String Expr
 
-{-
 instance Show OpKind where
   show Add = "+"
   show Sub = "-"
@@ -46,7 +45,6 @@ instance Show Expr where
 
 instance Show Rule where
   show Rule { hd=mHead, body=mBody} = show mHead <> " = " <> show mBody
--}
 
 -- Merge two bindings together removing duplicate keys binding different values
 mergeBindings :: Bindings -> Bindings -> Bindings
@@ -136,7 +134,10 @@ parsePow = parseLeftAssoc parseTerm sym
   where sym = ws *> charP '^' $> Op Pow <* ws
 
 parseTerm :: StrParser Expr
-parseTerm = parseFun <|> parseSymVar
+parseTerm = parseFun <|> parseSymVar <|> parseParens
+
+parseParens :: StrParser Expr
+parseParens = charP '(' *> ws *> parseExpr <* ws <* charP ')'
 
 parseFun :: StrParser Expr
 parseFun = do
@@ -152,4 +153,8 @@ parseSymVar = do
 
 commaSepArgs :: StrParser [Expr]
 commaSepArgs = 
-  charP '(' *> ws *> sepBy (ws *> charP ',' <* ws) parseTerm <* ws <* charP ')'
+  charP '(' *> ws *> sepBy (ws *> charP ',' <* ws) parseExpr <* ws <* charP ')'
+
+-- TODO user defined operators
+-- such a feature would require a context to store previously defined operators
+-- so subsequent uses of such operators could be parsed

--- a/src/Engine/Expr.hs
+++ b/src/Engine/Expr.hs
@@ -4,6 +4,7 @@ import Parsers
 import Prelude hiding (lookup, head)
 import Text.Printf (printf)
 import Control.Applicative
+import Data.Functor
 import Data.Char
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
@@ -16,7 +17,11 @@ data Expr
   = Sym String
   | Var String
   | Fun Expr [Expr]
-  deriving Eq
+  | Op OpKind Expr Expr
+  deriving (Eq, Show)
+
+data OpKind = Add | Sub | Mul | Div | Pow
+  deriving (Eq, Show)
 
 data Rule = Rule
   { hd :: Expr
@@ -25,13 +30,23 @@ data Rule = Rule
 
 type Bindings = Map String Expr
 
+{-
+instance Show OpKind where
+  show Add = "+"
+  show Sub = "-"
+  show Mul = "*"
+  show Div = "/"
+  show Pow = "^"
+
 instance Show Expr where
   show (Sym s) = s
   show (Var s) = s
   show (Fun head args) = printf "%s(%s)" (show head) (intercalate ", " (map show args))
+  show (Op kind lhs rhs) = printf "%s %s %s" (show lhs) (show kind) (show rhs)
 
 instance Show Rule where
   show Rule { hd=mHead, body=mBody} = show mHead <> " = " <> show mBody
+-}
 
 -- Merge two bindings together removing duplicate keys binding different values
 mergeBindings :: Bindings -> Bindings -> Bindings
@@ -46,12 +61,16 @@ mergeBindings = merge preserveMissing
 substBindings :: Bindings -> Expr -> Expr
 substBindings bindings expr =
   case expr of
-    Sym _         -> expr
-    Var name      -> fromMaybe expr (Map.lookup name bindings)
-    Fun head args ->
-      let new_head = substBindings bindings head
-          new_args = map (substBindings bindings) args in
-          Fun new_head new_args
+    Sym _           -> expr
+    Var name        -> fromMaybe expr (Map.lookup name bindings)
+    Fun head args   ->
+      let newHead = substBindings bindings head
+          newArgs = map (substBindings bindings) args in
+          Fun newHead newArgs
+    Op kind lhs rhs ->
+      let newLhs = substBindings bindings lhs
+          newRhs = substBindings bindings rhs in
+          Op kind newLhs newRhs
            
 -- Pattern match across two expressions creating a set of bindings between the
 -- two
@@ -61,9 +80,13 @@ match pattern value =
     (Var s1, _) -> Map.singleton s1 value
     (Sym s1, Sym s2) -> if s1 == s2 then Map.singleton s1 value else Map.empty
     (Fun name1 args1, Fun name2 args2) ->
-      if name1 /= name2 || length args1 /= length args2 
-         then Map.empty
-         else foldr1 mergeBindings $ zipWith match args1 args2
+      if name1 == name2 || length args1 == length args2 
+         then foldr1 mergeBindings $ zipWith match args1 args2
+         else Map.empty
+    (Op kind1 lhs1 rhs1, Op kind2 lhs2 rhs2) ->
+      if kind1 == kind2
+         then mergeBindings (match lhs1 lhs2) (match rhs1 rhs2)
+         else Map.empty
     _ -> Map.empty 
 
 -- Given a rule and an expression attempt to apply the rule to the expression
@@ -74,28 +97,16 @@ applyAll rule expr =
         case expr of
           Sym _ -> expr
           Var _ -> expr
-          Fun head args -> Fun (applyAll rule head) (map (applyAll rule) args)
+          Fun head args   -> Fun (applyAll rule head) (map (applyAll rule) args)
+          Op kind lhs rhs -> Op kind (applyAll rule lhs) (applyAll rule rhs)
       else
          substBindings bindings (body rule)
 
 {--PARSER----------------------------------------------------------------------}
 
-parseSymVar :: StrParser Expr
-parseSymVar = do
-  first <- alphaP <|> digitP -- [isUpper] will distinguish this case
-  rest  <- many (charP '_' <|> alphaP <|> digitP)
-  if isUpper first then parseFun (Var $ first:rest) <|> pure (Var $ first:rest)
-                   else parseFun (Sym $ first:rest) <|> pure (Sym $ first:rest)
-
-parseFun :: Expr -> StrParser Expr
-parseFun name = do
-  args <- charP '(' *> ws *>
-          sepBy (ws *> charP ',' <* ws)
-          parseSymVar <* ws <* charP ')'
-  pure $ Fun name args
-
-parseExpr :: StrParser Expr
-parseExpr = parseSymVar
+type GenericParser a = Parser Char String a
+type OpParser a = GenericParser (a -> a -> a) -- lhs -> rhs -> Op
+type ExprParser = GenericParser Expr
 
 parseRule :: StrParser Rule
 parseRule = do
@@ -103,3 +114,38 @@ parseRule = do
   _     <- ws *> charP '=' <* ws
   mBody <- parseExpr
   pure Rule { hd=mHead, body=mBody }
+
+parseLeftAssoc :: GenericParser a -> OpParser a -> GenericParser a
+parseLeftAssoc termParser opParser = do
+  first <- termParser
+  rest  <- many ((,) <$> opParser <*> termParser)
+  pure $ foldl (\acc (operator, next) -> operator acc next) first rest
+
+parseExpr :: GenericParser Expr
+parseExpr = parseLeftAssoc parseFactor (plus <|> minus) 
+  where plus = ws *> charP '+' $> Op Add <* ws
+        minus = ws *> charP '-' $> Op Sub <* ws
+
+parseFactor :: GenericParser Expr
+parseFactor = parseLeftAssoc parseTerm (mulP <|> divP) 
+  where mulP = ws *> charP '*' $> Op Mul <* ws
+        divP = ws *> charP '/' $> Op Div <* ws
+
+parseTerm :: StrParser Expr
+parseTerm = parseFun <|> parseSymVar
+
+parseFun :: StrParser Expr
+parseFun = do
+  name <- parseSymVar
+  Fun name <$> commaSepArgs
+
+parseSymVar :: StrParser Expr
+parseSymVar = do
+  first <- alphaP <|> digitP
+  rest  <- many (charP '_' <|> alphaP <|> digitP)
+  if isUpper first then pure (Var $ first:rest)
+                   else pure (Sym $ first:rest)
+
+commaSepArgs :: StrParser [Expr]
+commaSepArgs = 
+  charP '(' *> ws *> sepBy (ws *> charP ',' <* ws) parseTerm <* ws <* charP ')'

--- a/src/Engine/Expr.hs
+++ b/src/Engine/Expr.hs
@@ -127,9 +127,13 @@ parseExpr = parseLeftAssoc parseFactor (plus <|> minus)
         minus = ws *> charP '-' $> Op Sub <* ws
 
 parseFactor :: GenericParser Expr
-parseFactor = parseLeftAssoc parseTerm (mulP <|> divP) 
+parseFactor = parseLeftAssoc parsePow (mulP <|> divP) 
   where mulP = ws *> charP '*' $> Op Mul <* ws
         divP = ws *> charP '/' $> Op Div <* ws
+
+parsePow :: GenericParser Expr
+parsePow = parseLeftAssoc parseTerm sym
+  where sym = ws *> charP '^' $> Op Pow <* ws
 
 parseTerm :: StrParser Expr
 parseTerm = parseFun <|> parseSymVar


### PR DESCRIPTION
Introduce abstract binary operators to the core expression engine. Binary operators added are `+, -, *, / and ^` each has it's classic mathematical precedence. These operators are abstract in the sense that they act simply as infix shapes which can be pattern matched against, this notion of `lhs operator rhs` as well as precedence helps with reasoning about some rules and systems.

>Not included in this pull request but planned are **User Defined Operators**:
> It would be nice to implement a system allowing users to define there own infix operators similar to the system found in Haskell. Such a system would allow the operators defined in this pull to be user or *"standard library"* defined rather than baking them directly into the core expression language.
 